### PR TITLE
feat: multi-contributor bounty payout distribution

### DIFF
--- a/app/api/bounty/[owner]/[repo]/issues/[issueNumber]/route.ts
+++ b/app/api/bounty/[owner]/[repo]/issues/[issueNumber]/route.ts
@@ -59,6 +59,7 @@ type BountyResponse = {
   winning_pr_number: number | null;
   winning_pr_author: string | null;
   winning_pr_url: string | null;
+  winning_pr_coauthors: string[] | null;
   locked_at: string | null;
   paid_at: string | null;
   approved_by: string | null;
@@ -107,7 +108,7 @@ export async function GET(
   const { data: bounty, error: bountyError } = await supabase
     .from("bounties")
     .select(
-      "issue_id, status, total_amount, issue_title, issue_body, issue_state, issue_url, ledger_comment_id, payout_tx_hash, winning_pr_number, winning_pr_author, winning_pr_url, locked_at, paid_at, approved_by, created_at, updated_at",
+      "issue_id, status, total_amount, issue_title, issue_body, issue_state, issue_url, ledger_comment_id, payout_tx_hash, winning_pr_number, winning_pr_author, winning_pr_url, winning_pr_coauthors, locked_at, paid_at, approved_by, created_at, updated_at",
     )
     .eq("issue_id", issueId)
     .maybeSingle();
@@ -211,6 +212,9 @@ export async function GET(
     winning_pr_number: bounty.winning_pr_number,
     winning_pr_author: bounty.winning_pr_author,
     winning_pr_url: bounty.winning_pr_url,
+    winning_pr_coauthors: Array.isArray(bounty.winning_pr_coauthors)
+      ? (bounty.winning_pr_coauthors as string[])
+      : null,
     locked_at: bounty.locked_at,
     paid_at: bounty.paid_at,
     approved_by: bounty.approved_by,

--- a/app/b/[owner]/[repo]/issues/[issueNumber]/page.tsx
+++ b/app/b/[owner]/[repo]/issues/[issueNumber]/page.tsx
@@ -77,10 +77,41 @@ function renderActivityText(event: {
   }
 
   if (event.event_type === "BOUNTY_LOCKED") {
+    const coauthors =
+      typeof event.metadata === "object" &&
+      event.metadata !== null &&
+      "coauthors" in event.metadata &&
+      Array.isArray((event.metadata as { coauthors?: string[] }).coauthors)
+        ? (event.metadata as { coauthors: string[] }).coauthors
+        : null;
+    if (coauthors && coauthors.length > 0) {
+      const allNames = [event.actor_username ?? "unknown", ...coauthors].map(
+        (u) => `@${u}`,
+      );
+      return `Bounty locked after merge of PR #${event.pr_number ?? "?"} — split among ${allNames.join(", ")}`;
+    }
     return `Bounty locked after merge of PR #${event.pr_number ?? "?"}`;
   }
 
-  return `Bounty paid to @${event.actor_username ?? "unknown"} - tx ${event.tx_hash ?? "pending"}`;
+  if (event.event_type === "PAYOUT_SENT") {
+    const splitCount =
+      typeof event.metadata === "object" &&
+      event.metadata !== null &&
+      "split_count" in event.metadata
+        ? (event.metadata as { split_count?: number }).split_count
+        : null;
+    const splitTotal =
+      typeof event.metadata === "object" &&
+      event.metadata !== null &&
+      "split_total" in event.metadata
+        ? (event.metadata as { split_total?: number }).split_total
+        : null;
+    if (splitCount && splitCount > 1 && splitTotal) {
+      return `Paid $${formatAmount(event.amount ?? 0)} to @${event.actor_username ?? "unknown"} (${splitCount}-way split of $${formatAmount(splitTotal)}) - tx ${event.tx_hash ?? "pending"}`;
+    }
+    return `Bounty paid to @${event.actor_username ?? "unknown"} - tx ${event.tx_hash ?? "pending"}`;
+  }
+  return `Event: ${event.event_type}`;
 }
 
 function getActivityBadgeClass(eventType: string) {
@@ -229,6 +260,34 @@ export default async function BountyDetailPage(props: Props) {
               {bounty.status === "OPEN" ? (
                 <div className="mt-5">
                   <FundButton issueId={bounty.issue_id} issueUrl={issueUrl} />
+                </div>
+              ) : null}
+
+              {bounty.status === "LOCKED" &&
+              bounty.winning_pr_author ? (
+                <div className="mt-4 rounded-xl border border-zinc-800/80 bg-zinc-900/70 p-4">
+                  <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">
+                    Winner{bounty.winning_pr_coauthors && bounty.winning_pr_coauthors.length > 0 ? "s" : ""}
+                  </p>
+                  <div className="mt-2 space-y-1">
+                    <p className="text-sm text-emerald-300">
+                      @{bounty.winning_pr_author}
+                      {bounty.winning_pr_coauthors && bounty.winning_pr_coauthors.length > 0 && (
+                        <span className="text-zinc-400"> (PR author)</span>
+                      )}
+                    </p>
+                    {bounty.winning_pr_coauthors?.map((coauthor) => (
+                      <p key={coauthor} className="text-sm text-emerald-300">
+                        @{coauthor}
+                        <span className="text-zinc-400"> (co-author)</span>
+                      </p>
+                    ))}
+                  </div>
+                  {bounty.winning_pr_coauthors && bounty.winning_pr_coauthors.length > 0 && (
+                    <p className="mt-2 text-xs text-zinc-500">
+                      Bounty will be split ${(bounty.total_amount / (1 + bounty.winning_pr_coauthors.length)).toFixed(2)} USDC each
+                    </p>
+                  )}
                 </div>
               ) : null}
 

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -30,6 +30,7 @@ export type BountyDetail = {
   winning_pr_number: number | null;
   winning_pr_author: string | null;
   winning_pr_url: string | null;
+  winning_pr_coauthors: string[] | null;
   locked_at: string | null;
   paid_at: string | null;
   approved_by: string | null;

--- a/lib/bounty/coauthors.ts
+++ b/lib/bounty/coauthors.ts
@@ -1,0 +1,86 @@
+/**
+ * Utilities for extracting co-authors from pull request bodies.
+ *
+ * GitHub supports a `Co-authored-by:` trailer format in commit messages and PR bodies:
+ *   Co-authored-by: name <email>
+ *
+ * We parse these to identify additional contributors who should share the bounty.
+ */
+
+const CO_AUTHOR_REGEX =
+  /Co-authored-by:\s*([^<]+?)\s*<([^>]+)>/gi;
+
+export type CoAuthor = {
+  /** GitHub username extracted from the email (before @), or the raw name if not a GitHub noreply address */
+  name: string;
+  email: string;
+  /** GitHub username if derivable from the email, null otherwise */
+  githubUsername: string | null;
+};
+
+/**
+ * Extract co-author GitHub usernames from noreply addresses.
+ * GitHub noreply format: username@users.noreply.github.com
+ */
+function extractGithubUsername(email: string): string | null {
+  const noreplyMatch = /^([^@]+)@users\.noreply\.github\.com$/i.exec(email);
+  if (noreplyMatch) {
+    return noreplyMatch[1];
+  }
+  return null;
+}
+
+/**
+ * Parse co-authors from a PR body string.
+ * Returns an array of unique co-authors (deduped by email).
+ */
+export function parseCoAuthors(prBody: string | null): CoAuthor[] {
+  if (!prBody) return [];
+
+  const seen = new Set<string>();
+  const coAuthors: CoAuthor[] = [];
+
+  let match: RegExpExecArray | null;
+  // Reset lastIndex since we use /g flag
+  CO_AUTHOR_REGEX.lastIndex = 0;
+
+  while ((match = CO_AUTHOR_REGEX.exec(prBody)) !== null) {
+    const name = match[1].trim();
+    const email = match[2].trim().toLowerCase();
+
+    if (seen.has(email)) continue;
+    seen.add(email);
+
+    coAuthors.push({
+      name,
+      email,
+      githubUsername: extractGithubUsername(email),
+    });
+  }
+
+  return coAuthors;
+}
+
+/**
+ * Given a PR author username and co-authors parsed from the body,
+ * returns the full list of contributors (author first, then co-authors).
+ * Co-authors whose GitHub username matches the PR author are excluded.
+ */
+export function getAllContributors(
+  prAuthorUsername: string,
+  coAuthors: CoAuthor[],
+): string[] {
+  const contributors = [prAuthorUsername];
+  const seenUsernames = new Set<string>([prAuthorUsername.toLowerCase()]);
+
+  for (const coAuthor of coAuthors) {
+    const username = coAuthor.githubUsername?.toLowerCase();
+    if (username && !seenUsernames.has(username)) {
+      seenUsernames.add(username);
+      contributors.push(coAuthor.githubUsername!);
+    }
+    // If we can't derive a GitHub username, skip (we can't pay them without one)
+  }
+
+  return contributors;
+}

--- a/lib/bounty/handlers/pr-closed.ts
+++ b/lib/bounty/handlers/pr-closed.ts
@@ -6,6 +6,7 @@ import { buildLockedCommentBody } from "@/lib/bounty/ledger";
 import { prClosedPayloadSchema } from "@/lib/bounty/schemas/payloads";
 import { getSupabaseServiceClient } from "@/lib/clients/supabase/server";
 import { extractIssueNumberFromPrBody } from "@/lib/bounty/commands";
+import { parseCoAuthors, getAllContributors } from "@/lib/bounty/coauthors";
 
 async function getIssueInstallationClient(owner: string, repo: string, installationId?: number) {
   if (installationId) {
@@ -48,6 +49,10 @@ export async function handlePrClosed(eventPayload: unknown) {
     return { handled: false, reason: "no-bounty-or-already-paid" };
   }
 
+  // Extract co-authors from PR body
+  const coAuthors = parseCoAuthors(payload.pull_request.body);
+  const contributors = getAllContributors(payload.pull_request.user.login, coAuthors);
+
   const { error: lockError } = await supabase
     .from("bounties")
     .update({
@@ -55,6 +60,7 @@ export async function handlePrClosed(eventPayload: unknown) {
       winning_pr_number: payload.pull_request.number,
       winning_pr_author: payload.pull_request.user.login,
       winning_pr_url: payload.pull_request.html_url ?? null,
+      winning_pr_coauthors: contributors.length > 1 ? contributors.slice(1) : null,
       locked_at: new Date().toISOString(),
     })
     .eq("issue_id", issueId);
@@ -73,6 +79,7 @@ export async function handlePrClosed(eventPayload: unknown) {
     metadata: {
       source: "pull_request.closed",
       merged: true,
+      coauthors: contributors.length > 1 ? contributors.slice(1) : [],
     },
   });
 
@@ -86,6 +93,7 @@ export async function handlePrClosed(eventPayload: unknown) {
     issueId,
     bounty.total_amount,
     payload.pull_request.user.login,
+    contributors.length > 1 ? contributors.slice(1) : undefined,
   );
 
   await github.rest.issues.createComment({

--- a/lib/bounty/ledger.ts
+++ b/lib/bounty/ledger.ts
@@ -97,6 +97,7 @@ export function buildLockedCommentBody(
   issueId: string,
   amount: number,
   winnerUsername: string,
+  coAuthors?: string[],
 ): string {
   const bountyInfo = parseIssueId(issueId)!;
   const bountyUrl = `${process.env.NEXT_PUBLIC_APP_URL}/b/${bountyInfo.owner}/${bountyInfo.repo}/issues/${bountyInfo.issueNumber}`;
@@ -104,13 +105,31 @@ export function buildLockedCommentBody(
   const lines = [
     "🔒 **Bounty Locked**",
     "",
-    `@${winnerUsername} your PR was merged. Great work!`,
+  ];
+
+  if (coAuthors && coAuthors.length > 0) {
+    const allContributors = [winnerUsername, ...coAuthors];
+    const contributorMentions = allContributors.map((u) => `@${u}`).join(", ");
+    const perPersonAmount = (amount / allContributors.length).toFixed(2);
+
+    lines.push(
+      `${contributorMentions} — your PR was merged. Great work!`,
+      "",
+      `This bounty ($${amount.toFixed(2)} USDC) will be split equally among ${allContributors.length} contributors (~$${perPersonAmount} USDC each).`,
+    );
+  } else {
+    lines.push(
+      `@${winnerUsername} your PR was merged. Great work!`,
+    );
+  }
+
+  lines.push(
     "",
     `The bounty is now ready for payout. Please wait for the maintainers to release the bounty. [Bounty Page](${bountyUrl})`,
     "",
     "---",
     "_Bountic: Autonomous USDC bounties for open source_",
-  ];
+  );
 
   return lines.join("\n");
 }

--- a/lib/bounty/services/approve-payout.ts
+++ b/lib/bounty/services/approve-payout.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { resolveAndPayout } from "@/lib/bounty/services/payout";
+import { resolveAndPayout, resolveAndPayoutMulti } from "@/lib/bounty/services/payout";
 import { syncGithubBountyArtifacts } from "@/lib/bounty/services/github-sync";
 import { getSupabaseServiceClient } from "@/lib/clients/supabase/server";
 import { getGithubInstallationClient, getGithubRepoInstallationId } from "@/lib/clients/github/server";
@@ -17,7 +17,7 @@ export async function approveBountyPayout(params: {
 
   const { data: bounty, error: bountyError } = await supabase
     .from("bounties")
-    .select("issue_id, status, total_amount, winning_pr_author, winning_pr_number")
+    .select("issue_id, status, total_amount, winning_pr_author, winning_pr_number, winning_pr_coauthors")
     .eq("issue_id", issueId)
     .maybeSingle();
 
@@ -57,12 +57,98 @@ export async function approveBountyPayout(params: {
     }
   }
 
-  // only single payout for now, later multiple payouts
-  const payoutResult = await resolveAndPayout({
+  // Multi-contributor payout: split among PR author + co-authors
+  const coAuthors: string[] = Array.isArray(bounty.winning_pr_coauthors)
+    ? (bounty.winning_pr_coauthors as string[])
+    : [];
+  const contributors = [bounty.winning_pr_author, ...coAuthors];
+
+  if (contributors.length <= 1) {
+    // Single contributor — use the original flow
+    const payoutResult = await resolveAndPayout({
+      owner: params.owner,
+      repo: params.repo,
+      issueNumber: params.issueNumber,
+      winningPrAuthor: bounty.winning_pr_author,
+      winningPrBody,
+      amount: bounty.total_amount,
+      issueId,
+    });
+
+    const now = new Date().toISOString();
+
+    const { error: updateError } = await supabase
+      .from("bounties")
+      .update({
+        status: "PAID",
+        payout_tx_hash: payoutResult.txHash,
+        paid_at: now,
+        approved_by: params.approvedBy,
+      })
+      .eq("issue_id", issueId);
+
+    if (updateError) {
+      throw new Error(`Failed to update bounty status to PAID: ${updateError.message}`);
+    }
+
+    const { error: payoutEventError } = await supabase.from("payout_events").insert({
+      issue_id: issueId,
+      recipient_username: bounty.winning_pr_author,
+      amount: bounty.total_amount,
+      locus_transaction_id: payoutResult.transactionId,
+      transaction_hash: payoutResult.txHash,
+      status: "SUCCESS",
+      metadata: {
+        approved_by: params.approvedBy,
+        payout_source: "web",
+        payout_type: payoutResult.payoutType,
+        recipient_email: payoutResult.recipientEmail,
+        recipient_wallet: payoutResult.recipientWallet,
+      },
+    });
+
+    if (payoutEventError) {
+      throw new Error(`Failed to persist payout event: ${payoutEventError.message}`);
+    }
+
+    const { error: activityError } = await supabase.from("activity_events").insert({
+      issue_id: issueId,
+      event_type: "PAYOUT_SENT",
+      actor_username: bounty.winning_pr_author,
+      amount: bounty.total_amount,
+      tx_hash: payoutResult.txHash,
+      metadata: {
+        approved_by: params.approvedBy,
+        payout_source: "web",
+        payout_type: payoutResult.payoutType,
+      },
+    });
+
+    if (activityError) {
+      throw new Error(`Failed to persist payout activity: ${activityError.message}`);
+    }
+
+    await syncGithubBountyArtifacts(issueId);
+
+    return {
+      issueId,
+      amount: bounty.total_amount,
+      recipient: bounty.winning_pr_author,
+      payoutType: payoutResult.payoutType,
+      recipientEmail: payoutResult.recipientEmail,
+      recipientWallet: payoutResult.recipientWallet,
+      txHash: payoutResult.txHash,
+      transactionId: payoutResult.transactionId,
+      approvedBy: params.approvedBy,
+    };
+  }
+
+  // Multiple contributors — split the payout
+  const payoutResults = await resolveAndPayoutMulti({
     owner: params.owner,
     repo: params.repo,
     issueNumber: params.issueNumber,
-    winningPrAuthor: bounty.winning_pr_author,
+    contributors,
     winningPrBody,
     amount: bounty.total_amount,
     issueId,
@@ -70,11 +156,14 @@ export async function approveBountyPayout(params: {
 
   const now = new Date().toISOString();
 
+  // Use the first result's tx hash as the primary one
+  const primaryTxHash = payoutResults[0]?.txHash ?? null;
+
   const { error: updateError } = await supabase
     .from("bounties")
     .update({
       status: "PAID",
-      payout_tx_hash: payoutResult.txHash,
+      payout_tx_hash: primaryTxHash,
       paid_at: now,
       approved_by: params.approvedBy,
     })
@@ -84,54 +173,66 @@ export async function approveBountyPayout(params: {
     throw new Error(`Failed to update bounty status to PAID: ${updateError.message}`);
   }
 
-  const { error: payoutEventError } = await supabase.from("payout_events").insert({
-    issue_id: issueId,
-    recipient_username: bounty.winning_pr_author,
-    amount: bounty.total_amount,
-    locus_transaction_id: payoutResult.transactionId,
-    transaction_hash: payoutResult.txHash,
-    status: "SUCCESS",
-    metadata: {
-      approved_by: params.approvedBy,
-      payout_source: "web",
-      payout_type: payoutResult.payoutType,
-      recipient_email: payoutResult.recipientEmail,
-      recipient_wallet: payoutResult.recipientWallet,
-    },
-  });
+  // Create a payout event for each contributor
+  for (const result of payoutResults) {
+    const { error: payoutEventError } = await supabase.from("payout_events").insert({
+      issue_id: issueId,
+      recipient_username: result.contributor,
+      amount: result.share,
+      locus_transaction_id: result.transactionId,
+      transaction_hash: result.txHash,
+      status: "SUCCESS",
+      metadata: {
+        approved_by: params.approvedBy,
+        payout_source: "web",
+        payout_type: result.payoutType,
+        recipient_email: result.recipientEmail,
+        recipient_wallet: result.recipientWallet,
+        split_total: bounty.total_amount,
+        split_count: contributors.length,
+      },
+    });
 
-  if (payoutEventError) {
-    throw new Error(`Failed to persist payout event: ${payoutEventError.message}`);
+    if (payoutEventError) {
+      console.error(`Failed to persist payout event for ${result.contributor}:`, payoutEventError);
+    }
   }
 
-  const { error: activityError } = await supabase.from("activity_events").insert({
-    issue_id: issueId,
-    event_type: "PAYOUT_SENT",
-    actor_username: bounty.winning_pr_author,
-    amount: bounty.total_amount,
-    tx_hash: payoutResult.txHash,
-    metadata: {
-      approved_by: params.approvedBy,
-      payout_source: "web",
-      payout_type: payoutResult.payoutType,
-    },
-  });
+  // Create activity events for each contributor
+  for (const result of payoutResults) {
+    const { error: activityError } = await supabase.from("activity_events").insert({
+      issue_id: issueId,
+      event_type: "PAYOUT_SENT",
+      actor_username: result.contributor,
+      amount: result.share,
+      tx_hash: result.txHash,
+      metadata: {
+        approved_by: params.approvedBy,
+        payout_source: "web",
+        payout_type: result.payoutType,
+        split_total: bounty.total_amount,
+        split_count: contributors.length,
+      },
+    });
 
-  if (activityError) {
-    throw new Error(`Failed to persist payout activity: ${activityError.message}`);
+    if (activityError) {
+      console.error(`Failed to persist payout activity for ${result.contributor}:`, activityError);
+    }
   }
 
   await syncGithubBountyArtifacts(issueId);
 
+  // Return the primary author's result for backward compatibility
+  const primaryResult = payoutResults[0];
   return {
     issueId,
     amount: bounty.total_amount,
     recipient: bounty.winning_pr_author,
-    payoutType: payoutResult.payoutType,
-    recipientEmail: payoutResult.recipientEmail,
-    recipientWallet: payoutResult.recipientWallet,
-    txHash: payoutResult.txHash,
-    transactionId: payoutResult.transactionId,
+    payoutType: primaryResult.payoutType,
+    recipientEmail: primaryResult.recipientEmail,
+    recipientWallet: primaryResult.recipientWallet,
+    txHash: primaryResult.txHash,
+    transactionId: primaryResult.transactionId,
     approvedBy: params.approvedBy,
   };
 }

--- a/lib/bounty/services/payout.ts
+++ b/lib/bounty/services/payout.ts
@@ -174,3 +174,99 @@ export async function resolveAndPayout(params: {
     issueId: params.issueId,
   });
 }
+
+/**
+ * Resolve and pay a single contributor their share of a bounty.
+ */
+async function resolveAndPaySingleContributor(params: {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  contributorUsername: string;
+  winningPrBody: string | null;
+  amount: number;
+  issueId: string;
+}): Promise<PayoutResult> {
+  // Only extract wallet from PR body for the primary author
+  // (co-authors don't typically add their own wallet tags)
+  const walletFromPr = extractWalletFromPrBody(params.winningPrBody);
+  const recipientEmail = await getRecipientEmail(params.contributorUsername);
+
+  if (walletFromPr) {
+    return callLocusPayoutByWallet({
+      toAddress: walletFromPr,
+      amount: params.amount,
+      memo: `Bountic payout for ${params.issueId}`,
+    });
+  }
+
+  if (recipientEmail) {
+    return callLocusPayoutByEmail({
+      toEmail: recipientEmail,
+      amount: params.amount,
+      memo: `Bountic payout for ${params.issueId}`,
+    });
+  }
+
+  return handleUnclaimedPayout({
+    owner: params.owner,
+    repo: params.repo,
+    issueNumber: params.issueNumber,
+    winningPrAuthor: params.contributorUsername,
+    amount: params.amount,
+    issueId: params.issueId,
+  });
+}
+
+export type MultiPayoutResult = {
+  contributor: string;
+  share: number;
+} & PayoutResult;
+
+/**
+ * Distribute bounty payout among multiple contributors.
+ * The total amount is split equally. Any rounding remainder goes to the first contributor (PR author).
+ */
+export async function resolveAndPayoutMulti(params: {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  contributors: string[];
+  winningPrBody: string | null;
+  amount: number;
+  issueId: string;
+}): Promise<MultiPayoutResult[]> {
+  const { contributors } = params;
+
+  if (contributors.length === 0) {
+    throw new Error("At least one contributor is required");
+  }
+
+  if (contributors.length === 1) {
+    const result = await resolveAndPaySingleContributor({
+      ...params,
+      contributorUsername: contributors[0],
+    });
+    return [{ ...result, contributor: contributors[0], share: params.amount }];
+  }
+
+  // Split equally, with rounding remainder going to the first contributor (PR author)
+  const baseShare = Math.floor((params.amount / contributors.length) * 100) / 100;
+  const remainder = Math.round((params.amount - baseShare * contributors.length) * 100) / 100;
+
+  const results: MultiPayoutResult[] = [];
+
+  for (let i = 0; i < contributors.length; i++) {
+    const share = i === 0 ? baseShare + remainder : baseShare;
+
+    const result = await resolveAndPaySingleContributor({
+      ...params,
+      contributorUsername: contributors[i],
+      amount: share,
+    });
+
+    results.push({ ...result, contributor: contributors[i], share });
+  }
+
+  return results;
+}

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -45,6 +45,7 @@ export type Database = {
           winning_pr_number: number | null;
           winning_pr_author: string | null;
           winning_pr_url: string | null;
+          winning_pr_coauthors: Json | null;
           locked_at: string | null;
           paid_at: string | null;
           approved_by: string | null;
@@ -65,6 +66,7 @@ export type Database = {
           winning_pr_number?: number | null;
           winning_pr_author?: string | null;
           winning_pr_url?: string | null;
+          winning_pr_coauthors?: Json | null;
           locked_at?: string | null;
           paid_at?: string | null;
           approved_by?: string | null;
@@ -85,6 +87,7 @@ export type Database = {
           winning_pr_number?: number | null;
           winning_pr_author?: string | null;
           winning_pr_url?: string | null;
+          winning_pr_coauthors?: Json | null;
           locked_at?: string | null;
           paid_at?: string | null;
           approved_by?: string | null;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -136,6 +136,7 @@ alter table public.bounties add column if not exists issue_url text;
 alter table public.bounties add column if not exists winning_pr_number integer;
 alter table public.bounties add column if not exists winning_pr_author text;
 alter table public.bounties add column if not exists winning_pr_url text;
+alter table public.bounties add column if not exists winning_pr_coauthors jsonb;
 alter table public.bounties add column if not exists locked_at timestamptz;
 alter table public.bounties add column if not exists paid_at timestamptz;
 alter table public.bounties add column if not exists approved_by text;


### PR DESCRIPTION
## Summary

Parses Co-authored-by: trailers from merged PRs and splits bounty payouts equally among all contributors.

## Changes

- **New** lib/bounty/coauthors.ts — parse co-author trailers from PR body, extract GitHub usernames from noreply emails, deduplicate
- **DB migration** — adds winning_pr_coauthors jsonb column to ounties table
- **PR merge handler** — extracts and stores co-authors when PR is merged
- **Payout service** — new esolveAndPayoutMulti() for equal split (remainder to PR author)
- **Approve payout** — branches on single vs multi-contributor; creates separate payout/activity events per contributor
- **Ledger comment** — shows all contributors and per-person split in GitHub locked comment
- **UI** — bounty detail page shows co-authors and split info; activity feed shows split amounts
- **Types** — BountyDetail and database types updated

## Design Decisions

- **Backward compatible** — single-author PRs follow the exact same code path
- **Equal split** with rounding remainder to PR author
- **GitHub username required** for co-authors (derived from noreply addresses)
- **Per-contributor audit trail** via separate payout_events and activity_events rows

Closes #12