### PR TITLE
Support multi-contributor bounty payouts

### DIFF
--- a/app/b/[owner]/[repo]/issues/[issueNumber]/approve-button.tsx
+++ b/app/b/[owner]/[repo]/issues/[issueNumber]/approve-button.tsx
@@ -17,19 +17,21 @@ export function ApproveButton({ owner, repo, issueNumber }: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
-  const [successTxHash, setSuccessTxHash] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   const onApprove = () => {
     setError(null);
-    setSuccessTxHash(null);
+    setSuccessMessage(null);
 
     startTransition(async () => {
       try {
         const response = await approveBounty({ owner, repo, issueNumber });
-        const { payoutType, recipientEmail, recipientWallet } = response.payout;
-        
+        const { payoutType, recipientEmail, recipientWallet, recipients } = response.payout;
+
         let message = "";
-        if (payoutType === "wallet" && recipientWallet) {
+        if (recipients.length > 1) {
+          message = `Payout split across ${recipients.length} recipients.`;
+        } else if (payoutType === "wallet" && recipientWallet) {
           message = `Payout sent to wallet ${recipientWallet.slice(0, 6)}...${recipientWallet.slice(-4)}`;
         } else if (payoutType === "email" && recipientEmail) {
           message = `Payout sent to ${recipientEmail}`;
@@ -37,7 +39,7 @@ export function ApproveButton({ owner, repo, issueNumber }: Props) {
           message = "Winner not connected. Notified via issue comment to claim.";
         }
         
-        setSuccessTxHash(message);
+        setSuccessMessage(message);
         router.refresh();
       } catch (e) {
         setError(e instanceof Error ? e.message : "Failed to approve payout");
@@ -64,8 +66,8 @@ export function ApproveButton({ owner, repo, issueNumber }: Props) {
         )}
       </Button>
       {error ? <p className="mt-3 text-sm text-red-300">{error}</p> : null}
-      {successTxHash ? (
-        <p className="mt-3 text-sm text-emerald-300">{successTxHash}</p>
+      {successMessage ? (
+        <p className="mt-3 text-sm text-emerald-300">{successMessage}</p>
       ) : null}
     </div>
   );

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -166,6 +166,15 @@ export async function approveBounty(params: {
     txHash: string | null;
     transactionId: string;
     approvedBy: string;
+    recipients: Array<{
+      username: string;
+      amount: number;
+      payoutType: "wallet" | "email" | "unclaimed";
+      recipientEmail?: string | null;
+      recipientWallet?: string | null;
+      txHash: string | null;
+      transactionId: string;
+    }>;
   };
 }> {
   const res = await fetch(

--- a/lib/bounty/services/approve-payout.ts
+++ b/lib/bounty/services/approve-payout.ts
@@ -57,8 +57,7 @@ export async function approveBountyPayout(params: {
     }
   }
 
-  // only single payout for now, later multiple payouts
-  const payoutResult = await resolveAndPayout({
+  const payout = await resolveAndPayout({
     owner: params.owner,
     repo: params.repo,
     issueNumber: params.issueNumber,
@@ -67,6 +66,7 @@ export async function approveBountyPayout(params: {
     amount: bounty.total_amount,
     issueId,
   });
+  const primaryPayoutResult = payout.results[0];
 
   const now = new Date().toISOString();
 
@@ -74,7 +74,7 @@ export async function approveBountyPayout(params: {
     .from("bounties")
     .update({
       status: "PAID",
-      payout_tx_hash: payoutResult.txHash,
+      payout_tx_hash: primaryPayoutResult.txHash,
       paid_at: now,
       approved_by: params.approvedBy,
     })
@@ -84,38 +84,44 @@ export async function approveBountyPayout(params: {
     throw new Error(`Failed to update bounty status to PAID: ${updateError.message}`);
   }
 
-  const { error: payoutEventError } = await supabase.from("payout_events").insert({
+  const payoutEvents = payout.results.map((result) => ({
     issue_id: issueId,
-    recipient_username: bounty.winning_pr_author,
-    amount: bounty.total_amount,
-    locus_transaction_id: payoutResult.transactionId,
-    transaction_hash: payoutResult.txHash,
-    status: "SUCCESS",
+    recipient_username: result.recipientUsername,
+    amount: result.amount,
+    locus_transaction_id: result.transactionId,
+    transaction_hash: result.txHash,
+    status: "SUCCESS" as const,
     metadata: {
       approved_by: params.approvedBy,
       payout_source: "web",
-      payout_type: payoutResult.payoutType,
-      recipient_email: payoutResult.recipientEmail,
-      recipient_wallet: payoutResult.recipientWallet,
+      payout_type: result.payoutType,
+      recipient_email: result.recipientEmail,
+      recipient_wallet: result.recipientWallet,
+      split_payout: payout.isSplit,
     },
-  });
+  }));
+
+  const { error: payoutEventError } = await supabase.from("payout_events").insert(payoutEvents);
 
   if (payoutEventError) {
     throw new Error(`Failed to persist payout event: ${payoutEventError.message}`);
   }
 
-  const { error: activityError } = await supabase.from("activity_events").insert({
+  const activityEvents = payout.results.map((result) => ({
     issue_id: issueId,
-    event_type: "PAYOUT_SENT",
-    actor_username: bounty.winning_pr_author,
-    amount: bounty.total_amount,
-    tx_hash: payoutResult.txHash,
+    event_type: "PAYOUT_SENT" as const,
+    actor_username: result.recipientUsername,
+    amount: result.amount,
+    tx_hash: result.txHash,
     metadata: {
       approved_by: params.approvedBy,
       payout_source: "web",
-      payout_type: payoutResult.payoutType,
+      payout_type: result.payoutType,
+      split_payout: payout.isSplit,
     },
-  });
+  }));
+
+  const { error: activityError } = await supabase.from("activity_events").insert(activityEvents);
 
   if (activityError) {
     throw new Error(`Failed to persist payout activity: ${activityError.message}`);
@@ -126,12 +132,21 @@ export async function approveBountyPayout(params: {
   return {
     issueId,
     amount: bounty.total_amount,
-    recipient: bounty.winning_pr_author,
-    payoutType: payoutResult.payoutType,
-    recipientEmail: payoutResult.recipientEmail,
-    recipientWallet: payoutResult.recipientWallet,
-    txHash: payoutResult.txHash,
-    transactionId: payoutResult.transactionId,
+    recipient: primaryPayoutResult.recipientUsername,
+    payoutType: primaryPayoutResult.payoutType,
+    recipientEmail: primaryPayoutResult.recipientEmail,
+    recipientWallet: primaryPayoutResult.recipientWallet,
+    txHash: primaryPayoutResult.txHash,
+    transactionId: primaryPayoutResult.transactionId,
     approvedBy: params.approvedBy,
+    recipients: payout.results.map((result) => ({
+      username: result.recipientUsername,
+      amount: result.amount,
+      payoutType: result.payoutType,
+      recipientEmail: result.recipientEmail,
+      recipientWallet: result.recipientWallet,
+      txHash: result.txHash,
+      transactionId: result.transactionId,
+    })),
   };
 }

--- a/lib/bounty/services/payout.ts
+++ b/lib/bounty/services/payout.ts
@@ -6,19 +6,123 @@ import { getSupabaseServerEnv } from "@/lib/env/server";
 import { getGithubInstallationClient, getGithubRepoInstallationId } from "@/lib/clients/github/server";
 
 const BOUNTIC_ADDRESS_REGEX = /<!--\s*bountic-address:\s*(0x[a-fA-F0-9]{40})\s*-->/i;
+const BOUNTIC_SPLIT_REGEX = /<!--\s*bountic-split:\s*([\s\S]*?)-->/i;
+const BOUNTIC_SPLIT_LINE_REGEX =
+  /^@?([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?)\s+(\d+(?:\.\d+)?)(%)?(?:\s+(0x[a-fA-F0-9]{40}))?$/;
 
 export type PayoutResult = {
   transactionId: string;
   txHash: string | null;
   payoutType: "wallet" | "email" | "unclaimed";
+  recipientUsername: string;
+  amount: number;
   recipientEmail?: string | null;
   recipientWallet?: string | null;
+};
+
+export type PayoutResolution = {
+  results: PayoutResult[];
+  totalAmount: number;
+  isSplit: boolean;
+};
+
+type SplitRecipient = {
+  username: string;
+  amount: number;
+  wallet: string | null;
+};
+
+type RawSplitLine = {
+  username: string;
+  value: number;
+  isPercent: boolean;
+  wallet: string | null;
 };
 
 function extractWalletFromPrBody(prBody: string | null): string | null {
   if (!prBody) return null;
   const match = BOUNTIC_ADDRESS_REGEX.exec(prBody);
   return match ? match[1] : null;
+}
+
+function roundUsdc(amount: number): number {
+  return Math.round(amount * 100) / 100;
+}
+
+function parseSplitBlock(prBody: string | null): RawSplitLine[] {
+  if (!prBody) return [];
+
+  const match = BOUNTIC_SPLIT_REGEX.exec(prBody);
+  if (!match) return [];
+
+  return match[1]
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"))
+    .map((line) => {
+      const lineMatch = BOUNTIC_SPLIT_LINE_REGEX.exec(line);
+
+      if (!lineMatch) {
+        throw new Error(`Invalid bountic-split entry: "${line}"`);
+      }
+
+      return {
+        username: lineMatch[1],
+        value: Number(lineMatch[2]),
+        isPercent: Boolean(lineMatch[3]),
+        wallet: lineMatch[4] ?? null,
+      };
+    });
+}
+
+function resolveSplitRecipients(prBody: string | null, totalAmount: number): SplitRecipient[] {
+  const lines = parseSplitBlock(prBody);
+  if (lines.length === 0) return [];
+
+  const hasPercent = lines.some((line) => line.isPercent);
+  const hasFixedAmount = lines.some((line) => !line.isPercent);
+
+  if (hasPercent && hasFixedAmount) {
+    throw new Error("bountic-split cannot mix percentages and fixed USDC amounts");
+  }
+
+  const uniqueUsernames = new Set(lines.map((line) => line.username.toLowerCase()));
+  if (uniqueUsernames.size !== lines.length) {
+    throw new Error("bountic-split contains duplicate recipients");
+  }
+
+  if (hasPercent) {
+    const percentTotal = lines.reduce((sum, line) => sum + line.value, 0);
+    if (Math.abs(percentTotal - 100) > 0.001) {
+      throw new Error("bountic-split percentages must total 100%");
+    }
+
+    let allocated = 0;
+    return lines.map((line, index) => {
+      const isLast = index === lines.length - 1;
+      const amount = isLast
+        ? roundUsdc(totalAmount - allocated)
+        : roundUsdc((totalAmount * line.value) / 100);
+      allocated += amount;
+
+      return {
+        username: line.username,
+        amount,
+        wallet: line.wallet,
+      };
+    });
+  }
+
+  const fixedTotal = roundUsdc(lines.reduce((sum, line) => sum + line.value, 0));
+  if (Math.abs(fixedTotal - roundUsdc(totalAmount)) > 0.001) {
+    throw new Error("bountic-split fixed amounts must total the bounty amount");
+  }
+
+  return lines.map((line) => ({
+    username: line.username,
+    amount: roundUsdc(line.value),
+    wallet: line.wallet,
+  }));
 }
 
 async function getRecipientEmail(githubUsername: string): Promise<string | null> {
@@ -49,6 +153,7 @@ async function commentOnIssue(params: {
 }
 
 export async function callLocusPayoutByEmail(params: {
+  recipientUsername: string;
   toEmail: string;
   amount: number;
   memo: string;
@@ -73,6 +178,8 @@ export async function callLocusPayoutByEmail(params: {
       transactionId: payload.transaction_id,
       txHash: payload.tx_hash ?? null,
       payoutType: "email",
+      recipientUsername: params.recipientUsername,
+      amount: params.amount,
       recipientEmail: params.toEmail,
     };
   } catch (error) {
@@ -82,6 +189,7 @@ export async function callLocusPayoutByEmail(params: {
 }
 
 export async function callLocusPayoutByWallet(params: {
+  recipientUsername: string;
   toAddress: string;
   amount: number;
   memo: string;
@@ -104,6 +212,8 @@ export async function callLocusPayoutByWallet(params: {
     transactionId: payload.transaction_id,
     txHash: payload.tx_hash ?? null,
     payoutType: "wallet",
+    recipientUsername: params.recipientUsername,
+    amount: params.amount,
     recipientWallet: params.toAddress,
   };
 }
@@ -133,25 +243,27 @@ Once connected, a maintainer can approve your payout and the funds will be sent 
     transactionId: `unclaimed_${Date.now()}`,
     txHash: null,
     payoutType: "unclaimed",
+    recipientUsername: params.winningPrAuthor,
+    amount: params.amount,
     recipientEmail: null,
   };
 }
 
-export async function resolveAndPayout(params: {
+async function payoutRecipient(params: {
   owner: string;
   repo: string;
   issueNumber: number;
-  winningPrAuthor: string;
-  winningPrBody: string | null;
+  username: string;
+  wallet: string | null;
   amount: number;
   issueId: string;
 }): Promise<PayoutResult> {
-  const walletFromPr = extractWalletFromPrBody(params.winningPrBody);
-  const recipientEmail = await getRecipientEmail(params.winningPrAuthor);
+  const recipientEmail = await getRecipientEmail(params.username);
 
-  if (walletFromPr) {
+  if (params.wallet) {
     return callLocusPayoutByWallet({
-      toAddress: walletFromPr,
+      recipientUsername: params.username,
+      toAddress: params.wallet,
       amount: params.amount,
       memo: `Bountic payout for ${params.issueId}`,
     });
@@ -159,6 +271,7 @@ export async function resolveAndPayout(params: {
 
   if (recipientEmail) {
     return callLocusPayoutByEmail({
+      recipientUsername: params.username,
       toEmail: recipientEmail,
       amount: params.amount,
       memo: `Bountic payout for ${params.issueId}`,
@@ -169,8 +282,59 @@ export async function resolveAndPayout(params: {
     owner: params.owner,
     repo: params.repo,
     issueNumber: params.issueNumber,
-    winningPrAuthor: params.winningPrAuthor,
+    winningPrAuthor: params.username,
     amount: params.amount,
     issueId: params.issueId,
   });
+}
+
+export async function resolveAndPayout(params: {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  winningPrAuthor: string;
+  winningPrBody: string | null;
+  amount: number;
+  issueId: string;
+}): Promise<PayoutResolution> {
+  const splitRecipients = resolveSplitRecipients(params.winningPrBody, params.amount);
+
+  if (splitRecipients.length > 0) {
+    const results: PayoutResult[] = [];
+
+    for (const recipient of splitRecipients) {
+      results.push(await payoutRecipient({
+        owner: params.owner,
+        repo: params.repo,
+        issueNumber: params.issueNumber,
+        username: recipient.username,
+        wallet: recipient.wallet,
+        amount: recipient.amount,
+        issueId: params.issueId,
+      }));
+    }
+
+    return {
+      results,
+      totalAmount: params.amount,
+      isSplit: true,
+    };
+  }
+
+  const wallet = extractWalletFromPrBody(params.winningPrBody);
+  const result = await payoutRecipient({
+    owner: params.owner,
+    repo: params.repo,
+    issueNumber: params.issueNumber,
+    username: params.winningPrAuthor,
+    wallet,
+    amount: params.amount,
+    issueId: params.issueId,
+  });
+
+  return {
+    results: [result],
+    totalAmount: params.amount,
+    isSplit: false,
+  };
 }


### PR DESCRIPTION
## Summary

- Adds optional multi-contributor payout distribution via a hidden `bountic-split` block in the merged PR body.
- Supports either percentage splits that total 100% or fixed USDC splits that total the bounty amount.
- Persists one payout event and one activity event per recipient while preserving the existing single-recipient payout path.
- Updates the approval UI to show a split payout success message when multiple recipients are paid.

## Split format

```md
<!-- bountic-split:
@alice 60% 0x1111111111111111111111111111111111111111
@bob 40% 0x2222222222222222222222222222222222222222
-->
```

Fixed USDC amounts are also supported as long as they total the bounty amount.

## Test plan

- `npx pnpm run typecheck`
- `npx eslint 'app/b/[owner]/[repo]/issues/[issueNumber]/approve-button.tsx' lib/api/client.ts lib/bounty/services/approve-payout.ts lib/bounty/services/payout.ts`

Note: repo-wide `npx pnpm run lint` still reports pre-existing unrelated lint errors in `app/mock-checkout/[checkoutId]/page.tsx` and `app/page.tsx`.

Closes #12.

<!-- bountic-address: 0xdE6dd9624d46b833E2957d54010ADE5Aef5CCB33 -->
