### PR TITLE
fix: align wallet address tag with payout parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ This hackathon by Locus provided the exact infrastructure to solve this. So, I b
 1. Contributors search for open bounties.
 2. They open a PR linking the issue (e.g., `Fixes #123`, `Closes #123`). Bountic detects `pull_request.opened` and marks the PR as competing.
 3. **For AI Agents / Web3 Users:** Contributors embed their Locus wallet address directly in the PR markdown using a hidden comment: 
-   ``
+   `<!-- bountic-address: 0xYourWalletAddress -->`
+
+   The legacy `<!-- locus-wallet: 0xYourWalletAddress -->` tag is also supported for existing contributors.
 
 ### 3. Merge & Settle (Payout)
 1. The maintainer merges the winning PR (`pull_request.closed`).

--- a/lib/bounty/services/payout.ts
+++ b/lib/bounty/services/payout.ts
@@ -4,8 +4,7 @@ import { getLocusServerClient } from "@/lib/clients/locus/server";
 import { getSupabaseServiceClient } from "@/lib/clients/supabase/server";
 import { getSupabaseServerEnv } from "@/lib/env/server";
 import { getGithubInstallationClient, getGithubRepoInstallationId } from "@/lib/clients/github/server";
-
-const BOUNTIC_ADDRESS_REGEX = /<!--\s*bountic-address:\s*(0x[a-fA-F0-9]{40})\s*-->/i;
+import { BOUNTIC_ADDRESS_TAG_REGEX, LOCUS_WALLET_TAG_REGEX } from "@/lib/constants/bounty";
 
 export type PayoutResult = {
   transactionId: string;
@@ -17,7 +16,7 @@ export type PayoutResult = {
 
 function extractWalletFromPrBody(prBody: string | null): string | null {
   if (!prBody) return null;
-  const match = BOUNTIC_ADDRESS_REGEX.exec(prBody);
+  const match = BOUNTIC_ADDRESS_TAG_REGEX.exec(prBody) ?? LOCUS_WALLET_TAG_REGEX.exec(prBody);
   return match ? match[1] : null;
 }
 

--- a/lib/bounty/services/wallet.ts
+++ b/lib/bounty/services/wallet.ts
@@ -1,15 +1,16 @@
 import "server-only";
 
 import { getSupabaseServiceClient } from "@/lib/clients/supabase/server";
-
-const LOCUS_WALLET_REGEX = /<!--\s*locus-wallet:\s*(0x[a-fA-F0-9]{40})\s*-->/i;
+import { BOUNTIC_ADDRESS_TAG_REGEX, LOCUS_WALLET_TAG_REGEX } from "@/lib/constants/bounty";
 
 export async function resolveWalletAddress(params: {
   prDescription: string | null;
   prAuthorUsername: string;
 }): Promise<string | null> {
   if (params.prDescription) {
-    const walletMatch = LOCUS_WALLET_REGEX.exec(params.prDescription);
+    const walletMatch =
+      BOUNTIC_ADDRESS_TAG_REGEX.exec(params.prDescription) ??
+      LOCUS_WALLET_TAG_REGEX.exec(params.prDescription);
 
     if (walletMatch) {
       return walletMatch[1];

--- a/lib/constants/bounty.ts
+++ b/lib/constants/bounty.ts
@@ -9,3 +9,6 @@ export const BOUNTY_ISSUE_ID_REGEX =
 
 export const LOCUS_WALLET_TAG_REGEX =
   /<!--\s*locus-wallet:\s*(0x[a-fA-F0-9]{40})\s*-->/i;
+
+export const BOUNTIC_ADDRESS_TAG_REGEX =
+  /<!--\s*bountic-address:\s*(0x[a-fA-F0-9]{40})\s*-->/i;


### PR DESCRIPTION
This PR fixes an inconsistency between the documented wallet address tag and the tag parsed by the payout flow.

The issue states that the wallet address should be included using the documented bounty address tag, but the payout logic reads a different tag. This can cause valid submissions to be missed or not associated with the correct payout address.

Change included:
- Aligns the documented wallet address tag with the tag expected by the payout parser.

Verification:
- git diff --check passes.
- I could not run lint/typecheck locally because this environment does not have node, npm, pnpm, or corepack installed.

Payout address:

<!-- bountic-address: 0x21FA0031EDbe23DF5e4B11825ec614018d83080a -->