### PR TITLE
Add explicit split payout approval

### DIFF
--- a/app/api/bounty/[owner]/[repo]/issues/[issueNumber]/approve/route.ts
+++ b/app/api/bounty/[owner]/[repo]/issues/[issueNumber]/approve/route.ts
@@ -10,6 +10,21 @@ const routeParamsSchema = z.object({
   issueNumber: z.coerce.number().int().positive(),
 });
 
+const approveRequestSchema = z
+  .object({
+    splitPayouts: z
+      .array(
+        z.object({
+          githubUsername: z.string().min(1),
+          amount: z.coerce.number().positive(),
+          prNumber: z.coerce.number().int().positive().nullable().optional(),
+        }),
+      )
+      .min(1)
+      .optional(),
+  })
+  .optional();
+
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ owner: string; repo: string; issueNumber: string }> },
@@ -28,11 +43,15 @@ export async function POST(
   }
 
   try {
+    const rawBody = await request.text();
+    const body = rawBody.trim().length > 0 ? approveRequestSchema.parse(JSON.parse(rawBody)) : undefined;
+
     const result = await approveBountyPayout({
       owner: routeParams.owner,
       repo: routeParams.repo,
       issueNumber: routeParams.issueNumber,
       approvedBy: viewer.githubUsername,
+      splitPayouts: body?.splitPayouts,
     });
 
     return NextResponse.json({ success: true, payout: result });

--- a/app/b/[owner]/[repo]/issues/[issueNumber]/approve-button.tsx
+++ b/app/b/[owner]/[repo]/issues/[issueNumber]/approve-button.tsx
@@ -1,23 +1,66 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Loader2 } from "lucide-react";
 
 import { approveBounty } from "@/lib/api/client";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 type Props = {
   owner: string;
   repo: string;
   issueNumber: number;
+  totalAmount: number;
+  payoutCandidates: Array<{
+    githubUsername: string;
+    prNumber: number | null;
+  }>;
 };
 
-export function ApproveButton({ owner, repo, issueNumber }: Props) {
+type SplitRow = {
+  id: string;
+  githubUsername: string;
+  prNumber: string;
+  amount: string;
+};
+
+function toCents(amount: string): number {
+  const parsed = Number(amount);
+  return Number.isFinite(parsed) ? Math.round(parsed * 100) : 0;
+}
+
+export function ApproveButton({ owner, repo, issueNumber, totalAmount, payoutCandidates }: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
   const [successTxHash, setSuccessTxHash] = useState<string | null>(null);
+  const [useSplitPayout, setUseSplitPayout] = useState(false);
+  const [splitRows, setSplitRows] = useState<SplitRow[]>(() =>
+    payoutCandidates.length > 0
+      ? payoutCandidates.map((candidate, index) => ({
+          id: `${candidate.githubUsername}-${candidate.prNumber ?? "no-pr"}-${index}`,
+          githubUsername: candidate.githubUsername,
+          prNumber: candidate.prNumber ? String(candidate.prNumber) : "",
+          amount: index === 0 ? totalAmount.toFixed(2) : "0.00",
+        }))
+      : [
+          {
+            id: "winner",
+            githubUsername: "",
+            prNumber: "",
+            amount: totalAmount.toFixed(2),
+          },
+        ],
+  );
+
+  const allocatedCents = useMemo(
+    () => splitRows.reduce((sum, row) => sum + toCents(row.amount), 0),
+    [splitRows],
+  );
+  const totalCents = Math.round(totalAmount * 100);
+  const splitIsBalanced = allocatedCents === totalCents;
 
   const onApprove = () => {
     setError(null);
@@ -25,11 +68,22 @@ export function ApproveButton({ owner, repo, issueNumber }: Props) {
 
     startTransition(async () => {
       try {
-        const response = await approveBounty({ owner, repo, issueNumber });
+        const splitPayouts = useSplitPayout
+          ? splitRows
+              .filter((row) => toCents(row.amount) > 0)
+              .map((row) => ({
+                githubUsername: row.githubUsername,
+                amount: toCents(row.amount) / 100,
+                prNumber: row.prNumber.trim() ? Number(row.prNumber) : null,
+              }))
+          : undefined;
+        const response = await approveBounty({ owner, repo, issueNumber, splitPayouts });
         const { payoutType, recipientEmail, recipientWallet } = response.payout;
         
         let message = "";
-        if (payoutType === "wallet" && recipientWallet) {
+        if (response.payout.payouts && response.payout.payouts.length > 1) {
+          message = `Split payout sent to ${response.payout.payouts.length} recipients`;
+        } else if (payoutType === "wallet" && recipientWallet) {
           message = `Payout sent to wallet ${recipientWallet.slice(0, 6)}...${recipientWallet.slice(-4)}`;
         } else if (payoutType === "email" && recipientEmail) {
           message = `Payout sent to ${recipientEmail}`;
@@ -45,13 +99,92 @@ export function ApproveButton({ owner, repo, issueNumber }: Props) {
     });
   };
 
+  const updateSplitRow = (id: string, patch: Partial<SplitRow>) => {
+    setSplitRows((rows) => rows.map((row) => row.id === id ? { ...row, ...patch } : row));
+  };
+
+  const addSplitRow = () => {
+    setSplitRows((rows) => [
+      ...rows,
+      {
+        id: `manual-${Date.now()}`,
+        githubUsername: "",
+        prNumber: "",
+        amount: "0.00",
+      },
+    ]);
+  };
+
+  const removeSplitRow = (id: string) => {
+    setSplitRows((rows) => rows.length > 1 ? rows.filter((row) => row.id !== id) : rows);
+  };
+
   return (
     <div className="rounded-2xl border border-emerald-300/30 bg-emerald-400/5 p-4">
       <p className="text-xs uppercase tracking-[0.2em] text-emerald-300/80">Maintainer Action</p>
       <p className="mt-2 text-sm text-zinc-300">PR is merged and bounty is locked. Approve payout to release funds.</p>
+      <label className="mt-4 flex items-center gap-2 text-sm text-zinc-300">
+        <input
+          type="checkbox"
+          checked={useSplitPayout}
+          onChange={(event) => setUseSplitPayout(event.target.checked)}
+          className="h-4 w-4 rounded border-zinc-600 bg-zinc-900 text-emerald-400"
+        />
+        Split payout across contributors
+      </label>
+      {useSplitPayout ? (
+        <div className="mt-4 space-y-3">
+          <div className="grid grid-cols-[1fr_72px_88px_32px] gap-2 text-xs uppercase tracking-[0.12em] text-zinc-500">
+            <span>GitHub</span>
+            <span>PR</span>
+            <span>USDC</span>
+            <span />
+          </div>
+          {splitRows.map((row) => (
+            <div key={row.id} className="grid grid-cols-[1fr_72px_88px_32px] gap-2">
+              <Input
+                value={row.githubUsername}
+                onChange={(event) => updateSplitRow(row.id, { githubUsername: event.target.value })}
+                placeholder="username"
+                className="h-9 border-zinc-700 bg-zinc-950 text-sm text-zinc-100"
+              />
+              <Input
+                value={row.prNumber}
+                onChange={(event) => updateSplitRow(row.id, { prNumber: event.target.value.replace(/\D/g, "") })}
+                placeholder="#"
+                className="h-9 border-zinc-700 bg-zinc-950 text-sm text-zinc-100"
+              />
+              <Input
+                value={row.amount}
+                onChange={(event) => updateSplitRow(row.id, { amount: event.target.value })}
+                inputMode="decimal"
+                className="h-9 border-zinc-700 bg-zinc-950 text-sm text-zinc-100"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => removeSplitRow(row.id)}
+                disabled={splitRows.length === 1}
+                className="h-9 w-8 text-zinc-400 hover:text-zinc-100"
+              >
+                x
+              </Button>
+            </div>
+          ))}
+          <div className="flex items-center justify-between gap-3">
+            <Button type="button" variant="outline" onClick={addSplitRow} className="border-zinc-700 bg-zinc-950 text-zinc-200">
+              Add recipient
+            </Button>
+            <p className={splitIsBalanced ? "text-sm text-emerald-300" : "text-sm text-amber-300"}>
+              ${(allocatedCents / 100).toFixed(2)} / ${totalAmount.toFixed(2)}
+            </p>
+          </div>
+        </div>
+      ) : null}
       <Button
         onClick={onApprove}
-        disabled={isPending}
+        disabled={isPending || (useSplitPayout && !splitIsBalanced)}
         className="mt-4 h-10 w-full bg-emerald-400 text-black hover:bg-emerald-300"
       >
         {isPending ? (

--- a/app/b/[owner]/[repo]/issues/[issueNumber]/page.tsx
+++ b/app/b/[owner]/[repo]/issues/[issueNumber]/page.tsx
@@ -133,6 +133,37 @@ export default async function BountyDetailPage(props: Props) {
     bounty.issue_url ??
     `https://github.com/${owner}/${repo}/issues/${issueNumber}`;
   const nextPath = `/b/${owner}/${repo}/issues/${issueNumber}`;
+  const payoutCandidateMap = new Map<
+    string,
+    { githubUsername: string; prNumber: number | null; rank: number }
+  >();
+
+  if (bounty.winning_pr_author) {
+    payoutCandidateMap.set(bounty.winning_pr_author.toLowerCase(), {
+      githubUsername: bounty.winning_pr_author,
+      prNumber: bounty.winning_pr_number,
+      rank: 0,
+    });
+  }
+
+  for (const event of bounty.activity) {
+    if (event.event_type !== "PR_COMPETING" || !event.actor_username) {
+      continue;
+    }
+
+    const key = event.actor_username.toLowerCase();
+    if (!payoutCandidateMap.has(key)) {
+      payoutCandidateMap.set(key, {
+        githubUsername: event.actor_username,
+        prNumber: event.pr_number,
+        rank: 1,
+      });
+    }
+  }
+
+  const payoutCandidates = [...payoutCandidateMap.values()]
+    .sort((a, b) => a.rank - b.rank || a.githubUsername.localeCompare(b.githubUsername))
+    .map(({ githubUsername, prNumber }) => ({ githubUsername, prNumber }));
 
   return (
     <div className="mx-auto max-w-6xl px-5 py-10 sm:px-8">
@@ -239,6 +270,8 @@ export default async function BountyDetailPage(props: Props) {
                     owner={owner}
                     repo={repo}
                     issueNumber={Number(issueNumber)}
+                    totalAmount={bounty.total_amount}
+                    payoutCandidates={payoutCandidates}
                   />
                 </div>
               ) : null}

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -154,6 +154,11 @@ export async function approveBounty(params: {
   owner: string;
   repo: string;
   issueNumber: number;
+  splitPayouts?: Array<{
+    githubUsername: string;
+    amount: number;
+    prNumber?: number | null;
+  }>;
 }): Promise<{
   success: boolean;
   payout: {
@@ -166,12 +171,24 @@ export async function approveBounty(params: {
     txHash: string | null;
     transactionId: string;
     approvedBy: string;
+    splitPayout?: boolean;
+    payouts?: Array<{
+      amount: number;
+      recipient: string;
+      payoutType: "wallet" | "email" | "unclaimed";
+      recipientEmail: string | null;
+      recipientWallet: string | null;
+      txHash: string | null;
+      transactionId: string;
+    }>;
   };
 }> {
   const res = await fetch(
     `${API_BASE}/api/bounty/${params.owner}/${params.repo}/issues/${params.issueNumber}/approve`,
     {
       method: "POST",
+      headers: params.splitPayouts ? { "Content-Type": "application/json" } : undefined,
+      body: params.splitPayouts ? JSON.stringify({ splitPayouts: params.splitPayouts }) : undefined,
     },
   );
 

--- a/lib/bounty/services/approve-payout.ts
+++ b/lib/bounty/services/approve-payout.ts
@@ -1,16 +1,112 @@
 import "server-only";
 
-import { resolveAndPayout } from "@/lib/bounty/services/payout";
+import { resolveAndPayoutMany } from "@/lib/bounty/services/payout";
 import { syncGithubBountyArtifacts } from "@/lib/bounty/services/github-sync";
 import { getSupabaseServiceClient } from "@/lib/clients/supabase/server";
 import { getGithubInstallationClient, getGithubRepoInstallationId } from "@/lib/clients/github/server";
 import { buildIssueId } from "@/lib/bounty/issue-id";
+
+export type SplitPayoutInput = {
+  githubUsername: string;
+  amount: number;
+  prNumber?: number | null;
+};
+
+function toCents(amount: number): number {
+  return Math.round(amount * 100);
+}
+
+function normalizeSplitPayouts(params: {
+  splitPayouts?: SplitPayoutInput[];
+  totalAmount: number;
+  fallbackWinner: string;
+  fallbackPrNumber: number | null;
+}): Required<SplitPayoutInput>[] {
+  if (!params.splitPayouts?.length) {
+    return [
+      {
+        githubUsername: params.fallbackWinner,
+        amount: params.totalAmount,
+        prNumber: params.fallbackPrNumber,
+      },
+    ];
+  }
+
+  const seen = new Set<string>();
+  const normalized = params.splitPayouts.map((recipient) => {
+    const githubUsername = recipient.githubUsername.replace(/^@/, "").trim();
+    const amountCents = toCents(recipient.amount);
+
+    if (!githubUsername) {
+      throw new Error("Split payout recipients must include a GitHub username");
+    }
+
+    if (seen.has(githubUsername.toLowerCase())) {
+      throw new Error(`Duplicate split payout recipient: ${githubUsername}`);
+    }
+
+    if (amountCents <= 0) {
+      throw new Error(`Split payout amount for ${githubUsername} must be positive`);
+    }
+
+    seen.add(githubUsername.toLowerCase());
+
+    return {
+      githubUsername,
+      amount: amountCents / 100,
+      prNumber: recipient.prNumber ?? null,
+    };
+  });
+
+  const splitTotalCents = normalized.reduce((sum, recipient) => sum + toCents(recipient.amount), 0);
+  const bountyTotalCents = toCents(params.totalAmount);
+
+  if (splitTotalCents !== bountyTotalCents) {
+    throw new Error(
+      `Split payout total must equal bounty total: got $${(splitTotalCents / 100).toFixed(2)} of $${params.totalAmount.toFixed(2)}`,
+    );
+  }
+
+  return normalized;
+}
+
+async function fetchPrBodies(params: {
+  owner: string;
+  repo: string;
+  prNumbers: number[];
+}): Promise<Map<number, string | null>> {
+  const prBodies = new Map<number, string | null>();
+
+  if (params.prNumbers.length === 0) {
+    return prBodies;
+  }
+
+  const installationId = await getGithubRepoInstallationId(params.owner, params.repo);
+  const github = await getGithubInstallationClient(installationId);
+
+  for (const prNumber of params.prNumbers) {
+    try {
+      const prResponse = await github.rest.pulls.get({
+        owner: params.owner,
+        repo: params.repo,
+        pull_number: prNumber,
+      });
+      prBodies.set(prNumber, prResponse.data.body ?? null);
+    } catch (err) {
+      console.warn(`Failed to fetch PR #${prNumber} body for wallet extraction:`, err);
+      prBodies.set(prNumber, null);
+    }
+  }
+
+  return prBodies;
+}
 
 export async function approveBountyPayout(params: {
   owner: string;
   repo: string;
   issueNumber: number;
   approvedBy: string;
+  splitPayouts?: SplitPayoutInput[];
 }) {
   const issueId = buildIssueId(params.owner, params.repo, params.issueNumber);
   const supabase = getSupabaseServiceClient();
@@ -41,32 +137,34 @@ export async function approveBountyPayout(params: {
     throw new Error("No winning PR author found for payout");
   }
 
-  let winningPrBody: string | null = null;
-  if (bounty.winning_pr_number) {
-    try {
-      const installationId = await getGithubRepoInstallationId(params.owner, params.repo);
-      const github = await getGithubInstallationClient(installationId);
-      const prResponse = await github.rest.pulls.get({
-        owner: params.owner,
-        repo: params.repo,
-        pull_number: bounty.winning_pr_number,
-      });
-      winningPrBody = prResponse.data.body ?? null;
-    } catch (err) {
-      console.warn("Failed to fetch PR body for wallet extraction:", err);
-    }
-  }
+  const splitPayouts = normalizeSplitPayouts({
+    splitPayouts: params.splitPayouts,
+    totalAmount: bounty.total_amount,
+    fallbackWinner: bounty.winning_pr_author,
+    fallbackPrNumber: bounty.winning_pr_number ?? null,
+  });
 
-  // only single payout for now, later multiple payouts
-  const payoutResult = await resolveAndPayout({
+  const prNumbers = [...new Set(splitPayouts.flatMap((recipient) => recipient.prNumber ? [recipient.prNumber] : []))];
+  const prBodies = await fetchPrBodies({
+    owner: params.owner,
+    repo: params.repo,
+    prNumbers,
+  });
+
+  const payoutResults = await resolveAndPayoutMany({
     owner: params.owner,
     repo: params.repo,
     issueNumber: params.issueNumber,
-    winningPrAuthor: bounty.winning_pr_author,
-    winningPrBody,
-    amount: bounty.total_amount,
+    recipients: splitPayouts.map((recipient) => ({
+      githubUsername: recipient.githubUsername,
+      amount: recipient.amount,
+      prBody: recipient.prNumber ? prBodies.get(recipient.prNumber) ?? null : null,
+    })),
     issueId,
   });
+
+  const primaryPayout = payoutResults[0];
+  const payoutTxHash = payoutResults.find((result) => result.txHash)?.txHash ?? null;
 
   const now = new Date().toISOString();
 
@@ -74,7 +172,7 @@ export async function approveBountyPayout(params: {
     .from("bounties")
     .update({
       status: "PAID",
-      payout_tx_hash: payoutResult.txHash,
+      payout_tx_hash: payoutTxHash,
       paid_at: now,
       approved_by: params.approvedBy,
     })
@@ -84,38 +182,50 @@ export async function approveBountyPayout(params: {
     throw new Error(`Failed to update bounty status to PAID: ${updateError.message}`);
   }
 
-  const { error: payoutEventError } = await supabase.from("payout_events").insert({
-    issue_id: issueId,
-    recipient_username: bounty.winning_pr_author,
-    amount: bounty.total_amount,
-    locus_transaction_id: payoutResult.transactionId,
-    transaction_hash: payoutResult.txHash,
-    status: "SUCCESS",
-    metadata: {
-      approved_by: params.approvedBy,
-      payout_source: "web",
-      payout_type: payoutResult.payoutType,
-      recipient_email: payoutResult.recipientEmail,
-      recipient_wallet: payoutResult.recipientWallet,
-    },
-  });
+  const { error: payoutEventError } = await supabase.from("payout_events").insert(
+    payoutResults.map((payoutResult, index) => ({
+      issue_id: issueId,
+      recipient_username: payoutResult.recipient,
+      amount: payoutResult.amount,
+      locus_transaction_id: payoutResult.transactionId,
+      transaction_hash: payoutResult.txHash,
+      status: "SUCCESS" as const,
+      metadata: {
+        approved_by: params.approvedBy,
+        payout_source: "web",
+        payout_type: payoutResult.payoutType,
+        recipient_email: payoutResult.recipientEmail ?? null,
+        recipient_wallet: payoutResult.recipientWallet ?? null,
+        split_payout: payoutResults.length > 1,
+        split_index: index,
+        split_count: payoutResults.length,
+        pr_number: splitPayouts[index]?.prNumber ?? null,
+      },
+    })),
+  );
 
   if (payoutEventError) {
     throw new Error(`Failed to persist payout event: ${payoutEventError.message}`);
   }
 
-  const { error: activityError } = await supabase.from("activity_events").insert({
-    issue_id: issueId,
-    event_type: "PAYOUT_SENT",
-    actor_username: bounty.winning_pr_author,
-    amount: bounty.total_amount,
-    tx_hash: payoutResult.txHash,
-    metadata: {
-      approved_by: params.approvedBy,
-      payout_source: "web",
-      payout_type: payoutResult.payoutType,
-    },
-  });
+  const { error: activityError } = await supabase.from("activity_events").insert(
+    payoutResults.map((payoutResult, index) => ({
+      issue_id: issueId,
+      event_type: "PAYOUT_SENT" as const,
+      actor_username: payoutResult.recipient,
+      amount: payoutResult.amount,
+      pr_number: splitPayouts[index]?.prNumber ?? null,
+      tx_hash: payoutResult.txHash,
+      metadata: {
+        approved_by: params.approvedBy,
+        payout_source: "web",
+        payout_type: payoutResult.payoutType,
+        split_payout: payoutResults.length > 1,
+        split_index: index,
+        split_count: payoutResults.length,
+      },
+    })),
+  );
 
   if (activityError) {
     throw new Error(`Failed to persist payout activity: ${activityError.message}`);
@@ -126,12 +236,22 @@ export async function approveBountyPayout(params: {
   return {
     issueId,
     amount: bounty.total_amount,
-    recipient: bounty.winning_pr_author,
-    payoutType: payoutResult.payoutType,
-    recipientEmail: payoutResult.recipientEmail,
-    recipientWallet: payoutResult.recipientWallet,
-    txHash: payoutResult.txHash,
-    transactionId: payoutResult.transactionId,
+    recipient: primaryPayout.recipient,
+    payoutType: primaryPayout.payoutType,
+    recipientEmail: primaryPayout.recipientEmail ?? null,
+    recipientWallet: primaryPayout.recipientWallet ?? null,
+    txHash: payoutTxHash,
+    transactionId: primaryPayout.transactionId,
     approvedBy: params.approvedBy,
+    splitPayout: payoutResults.length > 1,
+    payouts: payoutResults.map((payoutResult) => ({
+      amount: payoutResult.amount,
+      recipient: payoutResult.recipient,
+      payoutType: payoutResult.payoutType,
+      recipientEmail: payoutResult.recipientEmail ?? null,
+      recipientWallet: payoutResult.recipientWallet ?? null,
+      txHash: payoutResult.txHash,
+      transactionId: payoutResult.transactionId,
+    })),
   };
 }

--- a/lib/bounty/services/payout.ts
+++ b/lib/bounty/services/payout.ts
@@ -15,7 +15,18 @@ export type PayoutResult = {
   recipientWallet?: string | null;
 };
 
-function extractWalletFromPrBody(prBody: string | null): string | null {
+export type PayoutRecipientInput = {
+  githubUsername: string;
+  prBody: string | null;
+  amount: number;
+};
+
+export type PayoutRecipientResult = PayoutResult & {
+  recipient: string;
+  amount: number;
+};
+
+export function extractWalletFromPrBody(prBody: string | null): string | null {
   if (!prBody) return null;
   const match = BOUNTIC_ADDRESS_REGEX.exec(prBody);
   return match ? match[1] : null;
@@ -137,17 +148,17 @@ Once connected, a maintainer can approve your payout and the funds will be sent 
   };
 }
 
-export async function resolveAndPayout(params: {
+export async function resolvePayoutRecipient(params: {
   owner: string;
   repo: string;
   issueNumber: number;
-  winningPrAuthor: string;
-  winningPrBody: string | null;
+  recipientUsername: string;
+  recipientPrBody: string | null;
   amount: number;
   issueId: string;
 }): Promise<PayoutResult> {
-  const walletFromPr = extractWalletFromPrBody(params.winningPrBody);
-  const recipientEmail = await getRecipientEmail(params.winningPrAuthor);
+  const walletFromPr = extractWalletFromPrBody(params.recipientPrBody);
+  const recipientEmail = await getRecipientEmail(params.recipientUsername);
 
   if (walletFromPr) {
     return callLocusPayoutByWallet({
@@ -169,7 +180,57 @@ export async function resolveAndPayout(params: {
     owner: params.owner,
     repo: params.repo,
     issueNumber: params.issueNumber,
-    winningPrAuthor: params.winningPrAuthor,
+    winningPrAuthor: params.recipientUsername,
+    amount: params.amount,
+    issueId: params.issueId,
+  });
+}
+
+export async function resolveAndPayoutMany(params: {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  recipients: PayoutRecipientInput[];
+  issueId: string;
+}): Promise<PayoutRecipientResult[]> {
+  const results: PayoutRecipientResult[] = [];
+
+  for (const recipient of params.recipients) {
+    const payout = await resolvePayoutRecipient({
+      owner: params.owner,
+      repo: params.repo,
+      issueNumber: params.issueNumber,
+      recipientUsername: recipient.githubUsername,
+      recipientPrBody: recipient.prBody,
+      amount: recipient.amount,
+      issueId: params.issueId,
+    });
+
+    results.push({
+      ...payout,
+      recipient: recipient.githubUsername,
+      amount: recipient.amount,
+    });
+  }
+
+  return results;
+}
+
+export async function resolveAndPayout(params: {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  winningPrAuthor: string;
+  winningPrBody: string | null;
+  amount: number;
+  issueId: string;
+}): Promise<PayoutResult> {
+  return resolvePayoutRecipient({
+    owner: params.owner,
+    repo: params.repo,
+    issueNumber: params.issueNumber,
+    recipientUsername: params.winningPrAuthor,
+    recipientPrBody: params.winningPrBody,
     amount: params.amount,
     issueId: params.issueId,
   });

--- a/public/LLM.md
+++ b/public/LLM.md
@@ -146,6 +146,31 @@ Response:
 
 Requires GitHub OAuth session + repo permission (admin/maintain/write).
 
+Optional body for explicit multi-contributor payout:
+```
+{
+  "splitPayouts": [
+    {
+      "githubUsername": "contributor-a",
+      "amount": 6.25,
+      "prNumber": 14
+    },
+    {
+      "githubUsername": "contributor-b",
+      "amount": 3.75,
+      "prNumber": 30
+    }
+  ]
+}
+```
+
+Rules:
+- When omitted, approval pays the locked winning PR author the full bounty, matching the original behavior.
+- When provided, `splitPayouts` amounts must be positive and must sum exactly to the bounty total in cents.
+- `githubUsername` values must be unique after removing an optional leading `@`.
+- `prNumber` is optional, but when present Bountic reads that PR body for the wallet tag.
+- Each split recipient creates its own `payout_events` row and `PAYOUT_SENT` activity event.
+
 Response:
 ```
 {
@@ -159,7 +184,19 @@ Response:
     "recipientWallet": null,
     "txHash": null,
     "transactionId": "...",
-    "approvedBy": "github_username"
+    "approvedBy": "github_username",
+    "splitPayout": false,
+    "payouts": [
+      {
+        "amount": 0,
+        "recipient": "...",
+        "payoutType": "wallet|email|unclaimed",
+        "recipientEmail": null,
+        "recipientWallet": null,
+        "txHash": null,
+        "transactionId": "..."
+      }
+    ]
   }
 }
 ```


### PR DESCRIPTION
<!-- bountic-address: 0xE844D209fc73C8b2b271C752abECe414e6b2061D -->

## Summary
- Add an optional `splitPayouts` approval payload so maintainers can explicitly distribute a locked bounty across multiple GitHub contributors.
- Validate split recipients by unique GitHub username and exact cent-level total before sending any payout.
- Resolve each recipient through their PR wallet tag, registered email fallback, or unclaimed payout flow, then persist payout/activity rows per recipient.
- Add a maintainer UI for split rows prefilled from competing PR activity, while keeping the existing single-winner approval path unchanged.
- Document the multi-contributor approval contract in `public/LLM.md` for agent-readable usage.

## Validation
- `tsc --noEmit`
- focused ESLint on touched files
- `git diff --check`

Fixes #12